### PR TITLE
レビュアーを自動アサインするActionを追加

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,9 @@
+# https://github.com/kentaro-m/auto-assign-action
+
+addReviewers: true
+addAssignees: false
+
+reviewers:
+  - rmuraix
+
+numberOfReviewers: 1

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,10 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
## 関連するIssue

## 変更内容

- [kentaro-m/auto-assign-action](https://github.com/kentaro-m/auto-assign-action)を使ってレビュアーを自動アサインする

## 備考

General actions permissionsのPoliciesでホワイトリスト対応済み