### PR TITLE
chore: docs/**を言語統計に含める

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/** -linguist-documentation


### PR DESCRIPTION
## 関連するIssue

## 変更内容

- GitHubのリポジトリごとの言語統計は、既定で`docs/**`を集計しない。せっかくなので集計するように変更する

## 備考

https://github.com/github-linguist/linguist/blob/main/docs/troubleshooting.md
https://github.com/github-linguist/linguist/blob/main/docs/overrides.md